### PR TITLE
handle wiki links as obsidian urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Your mileage may vary though.
 
 ## Settings
 
-The filter can be configured per-vault by putting a file `.obsidian-md-filter` in the root of the vault. This must be a YAML file. Currently it supports five settings:
+The filter can be configured per-vault by putting a file `.obsidian-md-filter` in the root of the vault. This must be a YAML file. Currently it supports the following settings:
 
 ```yaml
 strip_emojis: true
@@ -64,6 +64,7 @@ add_title: true
 convert_tags: true
 obsidian_links: true
 convert_markdown_links: true
+marked_processor: discount
 ```
 
 - `strip_emojis`: remove emojis in the preview
@@ -71,3 +72,4 @@ convert_markdown_links: true
 - `convert_tags`: convert `#tags` to styled tags in preview
 - `obsidian_links`: if true, links in the document are converted to `obsidian://` urls and will open the linked notes in Obsidian
 - `convert_markdown_links`: if true, links created in the "portable" format (`[label](link)`) will be converted to `obsidian://` links. Only use this if you don't have `[[wikilinks]]` as your default link type
+- `marked_processor`: can be set to `mmd` or `multimarkdown` to remove spaces from the slug (#My anchor => Myanchor), which is compatible with the way MultiMarkdown creates anchors from headlines. Any other value will generate anchors as hyphenated slugs (#My anchor => my-anchor).

--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ What does the filter do? The main idea is that the output of the filter is a doc
 - Adds the filename as a level 1 title at the top, if enabled (see Settings below).
 - Strips any YAML front matter (I can never get it to work reliably in Marked 2 itself)
 - Strips HTML comments
-- Replaces internal Obsidian links with just the text of the link.
-    - `[[Link to other page|Alias]]` becomes `[Alias](obsidian url to other page)`
-    - `[[Link to other page]]` becomes `[Link to other page](obsidian url to other page)`
-    - `[[Link to other page#Reference]]` becomes `[Link to other page > Reference](obsidian url to "other page" with anchor)`
-    - `[[#Reference]]` becomes `[Reference](#reference)`. This will only work if the Processor in Marked is set to Discount (GFM).
+- Replaces internal Obsidian links with just the text of the link, or with Obsidian links, based on settings.
+    - If `obsidian_links` is set to `true`
+        - `[[Link to other page|Alias]]` becomes `[Alias](obsidian url to other page)`
+        - `[[Link to other page]]` becomes `[Link to other page](obsidian url to other page)`
+        - `[[Link to other page#Reference]]` becomes `[Link to other page > Reference](obsidian url to "other page" with anchor)`
+        - `[[#Reference]]` becomes `[Reference](#reference)`. This will only work if the Processor in Marked is set to Discount (GFM).
+    - If `obsidian_links` is false or not set
+        - `[[Link to other page|Alias]]` becomes `Alias`
+        - `[[Link to other page]]` becomes `Link to other page`
+        - `[[Link to other page#Reference]]` becomes `Link to other page > Reference`
+        - `[[#Reference]]` becomes `Reference`
 - `#tag` gets styled as a tag in Marked Preview
 - Replaces transclusions with IA Writer block syntax
     - `![[File to include]]` becomes `/path/to/File to include.extension`
@@ -50,9 +56,18 @@ Your mileage may vary though.
 
 ## Settings
 
-The filter can be configured per-vault by putting a file `.obsidian-md-filter` in the root of the vault. This must be a YAML file. Currently it supports two settings:
+The filter can be configured per-vault by putting a file `.obsidian-md-filter` in the root of the vault. This must be a YAML file. Currently it supports five settings:
 
 ```yaml
 strip_emojis: true
 add_title: true
+convert_tags: true
+obsidian_links: true
+convert_markdown_links: true
 ```
+
+- `strip_emojis`: remove emojis in the preview
+- `add_title`: include the title of the note as an H1 in the preview 
+- `convert_tags`: convert `#tags` to styled tags in preview
+- `obsidian_links`: if true, links in the document are converted to `obsidian://` urls and will open the linked notes in Obsidian
+- `convert_markdown_links`: if true, links created in the "portable" format (`[label](link)`) will be converted to `obsidian://` links. Only use this if you don't have `[[wikilinks]]` as your default link type

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ What does the filter do? The main idea is that the output of the filter is a doc
 - Strips any YAML front matter (I can never get it to work reliably in Marked 2 itself)
 - Strips HTML comments
 - Replaces internal Obsidian links with just the text of the link.
-    - `[[Link to other page|Alias]]` becomes `Alias`
-    - `[[Link to other page]]` becomes `Link to other page`
-    - `[[Link to other page#Reference]]` becomes `Link to other page > Reference`
-    - `[[#Reference]]` becomes `Reference`
+    - `[[Link to other page|Alias]]` becomes `[Alias](obsidian url to other page)`
+    - `[[Link to other page]]` becomes `[Link to other page](obsidian url to other page)`
+    - `[[Link to other page#Reference]]` becomes `[Link to other page > Reference](obsidian url to "other page" with anchor)`
+    - `[[#Reference]]` becomes `[Reference](#reference)`. This will only work if the Processor in Marked is set to Discount (GFM).
+- `#tag` gets styled as a tag in Marked Preview
 - Replaces transclusions with IA Writer block syntax
     - `![[File to include]]` becomes `/path/to/File to include.extension`
 - Strips block IDs from the content

--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -49,7 +49,7 @@ class Vault
   end
 
   def convert_markdown_links?
-    settings[:obsidian_links]
+    settings[:convert_markdown_links]
   end
 
   def vault

--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -1,6 +1,7 @@
 #!/usr/bin/ruby
 require 'singleton'
 require 'yaml'
+require 'erb'
 
 Encoding.default_internal = Encoding::UTF_8
 Encoding.default_external = Encoding::UTF_8
@@ -27,6 +28,10 @@ class Vault
 
   def add_title?
     settings[:add_title]
+  end
+
+  def vault
+    @vault ||= ERB::Util.url_encode(File.basename(root))
   end
 
   private
@@ -104,10 +109,10 @@ $stdin.readlines.each do |line|
   end
 
   # ^block-id on its own line -> skip completely
-  next if line =~ /^\^[a-zA-Z0-9\-]+$/
+  next if line =~ /^\^[a-zA-Z0-9-]+$/
 
   # ^block-id at the end of a line? -> strip off
-  line.gsub!(/^(.*?)\s\^[a-zA-Z0-9\-]+$/, '\1')
+  line.gsub!(/^(.*?)\s\^[a-zA-Z0-9-]+$/, '\1')
   # ![[Include This]], on a single line -> /path/to/reference
   if line =~ /^!\[\[(.*?)\]\]$/
     path = Vault.instance.resolve(Regexp.last_match(1))
@@ -119,29 +124,43 @@ $stdin.readlines.each do |line|
   else
     # Remove emojis if needed
     line.gsub!(EMOJI_REGEX, '') if Vault.instance.strip_emojis?
+    # Style #tags
+    line.gsub!(/(?<=\A|\s)#(\S+)/, '<span class="mkstyledtag">#\1</span>')
     # Fix all [[WikiLinks]]
     replacements = {}
+    vault = Vault.instance.vault
     line.scan(/(\[\[(.*?)\]\])/) do |match|
       wikilink = match[0]
       text = match[1]
       link, label = text.split('|')
       page, anchor = link.split('#')
+
       replacements[wikilink] = if !label.nil?
-                                 # [[Internal link|Alias]] -> Alias
-                                 label
+                                 # [[Internal link|Alias]] -> [Alias](obsidian url)
+                                 "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode(link)})"
                                elsif !anchor.nil?
                                  if page.empty?
-                                   # [[#Reference]] -> Reference
-                                   anchor
+                                   # [[#A Reference]] -> [A Reference](#a-reference)
+                                   "[#{anchor}](##{anchor.downcase.gsub(/[^a-z0-9%]/i, '-').gsub(/%20/, '-').gsub(/-+/, '-')})"
                                  else
-                                   # [[Internal link#Reference]] -> Internal link > Reference
-                                   "#{page} > #{anchor}"
+                                   # [[Internal link#Reference]] -> [Internal link > Reference](obsidian url to page#anchor)
+                                   "[#{page} > #{anchor}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{page}##{anchor}")})"
                                  end
                                else
-                                 # [[Internal link]] -> Internal link
-                                 page
+                                 page = anchor.nil? ? page : "#{page} > #{anchor}"
+                                 "[#{page}](obsidian://vault/#{vault}/#{ERB::Util.url_encode(page)})"
                                end
     end
+    # Match []() style links and convert to Obsidian urls
+    line.scan(/\[(?<label>.*?)\]\((?<note>[^#]+)(?:\.md)?(?<anchor>#.*?)?\)/) do
+      m = Regexp.last_match
+      wikilink = m[0]
+      label = m['label']
+      link = m['note']
+      anchor = m['anchor']
+      replacements[wikilink] = "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{link}#{anchor}")})"
+    end
+
     replacements.each_pair { |k, v| line.gsub!(k, v) }
     puts line
   end

--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -6,6 +6,12 @@ require 'erb'
 Encoding.default_internal = Encoding::UTF_8
 Encoding.default_external = Encoding::UTF_8
 
+class ::String
+  def slugify
+    downcase.gsub(/%20/, '-').gsub(/[^a-z0-9%]/i, '-').gsub(/-+/, '-')
+  end
+end
+
 class Vault
   include Singleton
 
@@ -28,6 +34,18 @@ class Vault
 
   def add_title?
     settings[:add_title]
+  end
+
+  def convert_tags?
+    settings[:convert_tags]
+  end
+
+  def obsidian_links?
+    settings[:obsidian_links]
+  end
+
+  def convert_markdown_links?
+    settings[:obsidian_links]
   end
 
   def vault
@@ -63,7 +81,10 @@ class Vault
              end
     {
       strip_emojis: config['strip_emojis'] || false,
-      add_title: config['add_title'] || false
+      add_title: config['add_title'] || false,
+      convert_tags: config['convert_tags'] || false,
+      obsidian_links: config['obsidian_links'] || false,
+      convert_markdown_links: config['convert_markdown_links'] || false
     }
   end
 end
@@ -72,6 +93,59 @@ end
 unless Vault.instance.valid?
   puts 'NOCUSTOM'
   return
+end
+
+def obsidian_links(line, vault)
+  replacements = {}
+  line.scan(/(\[\[(.*?)\]\])/) do |match|
+    wikilink = match[0]
+    text = match[1]
+    link, label = text.split('|')
+    page, anchor = link.split('#')
+
+    replacements[wikilink] = if !label.nil?
+                               # [[Internal link|Alias]] -> [Alias](obsidian url)
+                               "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode(link)})"
+                             elsif !anchor.nil?
+                               if page.empty?
+                                 # [[#A Reference]] -> [A Reference](#a-reference)
+                                 "[#{anchor}](##{anchor.slugify})"
+                               else
+                                 # [[Internal link#Reference]] -> [Internal link > Reference](obsidian url to page#anchor)
+                                 "[#{page} > #{anchor}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{page}##{anchor}")})"
+                               end
+                             else
+                               page = anchor.nil? ? page : "#{page} > #{anchor}"
+                               "[#{page}](obsidian://vault/#{vault}/#{ERB::Util.url_encode(page)})"
+                             end
+  end
+  replacements
+end
+
+def strip_links(line)
+  replacements = {}
+  line.scan(/(\[\[(.*?)\]\])/) do |match|
+    wikilink = match[0]
+    text = match[1]
+    link, label = text.split('|')
+    page, anchor = link.split('#')
+    replacements[wikilink] = if !label.nil?
+                               # [[Internal link|Alias]] -> Alias
+                               label
+                             elsif !anchor.nil?
+                               if page.empty?
+                                 # [[#Reference]] -> Reference
+                                 anchor
+                               else
+                                 # [[Internal link#Reference]] -> Internal link > Reference
+                                 "#{page} > #{anchor}"
+                               end
+                             else
+                               # [[Internal link]] -> Internal link
+                               page
+                             end
+  end
+  replacements
 end
 
 # Source: https://github.com/guanting112/remove_emoji
@@ -87,6 +161,8 @@ end
 first = true
 front_matter = false
 comment = false
+vault = Vault.instance.vault
+
 $stdin.readlines.each do |line|
   # Strip out the YAML front matter, if any.
   if first
@@ -124,41 +200,33 @@ $stdin.readlines.each do |line|
   else
     # Remove emojis if needed
     line.gsub!(EMOJI_REGEX, '') if Vault.instance.strip_emojis?
-    # Style #tags
-    line.gsub!(/(?<=\A|\s)#(\S+)/, '<span class="mkstyledtag">#\1</span>')
+    # Style #tags (settings['convert_tags'])
+    line.gsub!(/(?<=\A|\s)#(\S+)/, '<span class="mkstyledtag">#\1</span>') if Vault.instance.convert_tags?
     # Fix all [[WikiLinks]]
-    replacements = {}
-    vault = Vault.instance.vault
-    line.scan(/(\[\[(.*?)\]\])/) do |match|
-      wikilink = match[0]
-      text = match[1]
-      link, label = text.split('|')
-      page, anchor = link.split('#')
+    replacements = if Vault.instance.obsidian_links?
+                     obsidian_links(line, vault)
+                   else
+                     strip_links(line)
+                   end
 
-      replacements[wikilink] = if !label.nil?
-                                 # [[Internal link|Alias]] -> [Alias](obsidian url)
-                                 "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode(link)})"
-                               elsif !anchor.nil?
-                                 if page.empty?
-                                   # [[#A Reference]] -> [A Reference](#a-reference)
-                                   "[#{anchor}](##{anchor.downcase.gsub(/[^a-z0-9%]/i, '-').gsub(/%20/, '-').gsub(/-+/, '-')})"
-                                 else
-                                   # [[Internal link#Reference]] -> [Internal link > Reference](obsidian url to page#anchor)
-                                   "[#{page} > #{anchor}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{page}##{anchor}")})"
-                                 end
-                               else
-                                 page = anchor.nil? ? page : "#{page} > #{anchor}"
-                                 "[#{page}](obsidian://vault/#{vault}/#{ERB::Util.url_encode(page)})"
-                               end
-    end
-    # Match []() style links and convert to Obsidian urls
-    line.scan(/\[(?<label>.*?)\]\((?<note>[^#]+)(?:\.md)?(?<anchor>#.*?)?\)/) do
-      m = Regexp.last_match
-      wikilink = m[0]
-      label = m['label']
-      link = m['note']
-      anchor = m['anchor']
-      replacements[wikilink] = "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{link}#{anchor}")})"
+    if Vault.instance.convert_markdown_links?
+      # Match []() style links and convert to Obsidian urls
+      line.scan(/\[(?<label>.*?)\]\((?<note>[^#]+)(?:\.md)?(?<anchor>#.*?)?\)/) do
+        m = Regexp.last_match
+        wikilink = m[0]
+        label = m['label']
+        link = m['note']
+        anchor = m['anchor']
+        replacements[wikilink] = "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{link}#{anchor}")})"
+      end
+
+      line.scan(/\[(?<label>.*?)\]\(#(?<anchor>.*?)\)/) do
+        m = Regexp.last_match
+        wikilink = m[0]
+        label = m['label']
+        anchor = m['anchor']
+        replacements[wikilink] = "[#{label}](##{anchor.slugify})"
+      end
     end
 
     replacements.each_pair { |k, v| line.gsub!(k, v) }

--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -8,7 +8,11 @@ Encoding.default_external = Encoding::UTF_8
 
 class ::String
   def slugify
-    downcase.gsub(/%20/, '-').gsub(/[^a-z0-9%]/i, '-').gsub(/-+/, '-')
+    if Vault.instance.mmd?
+      gsub(/%20/, '').gsub(/[^a-z0-9%]/i, '')
+    else
+      downcase.gsub(/%20/, '-').gsub(/[^a-z0-9%]/i, '-').gsub(/-+/, '-')
+    end
   end
 end
 
@@ -52,6 +56,14 @@ class Vault
     @vault ||= ERB::Util.url_encode(File.basename(root))
   end
 
+  def mmd
+    @mmd ||= settings[:marked_processor] =~ /^(mult|mmd)/
+  end
+
+  def mmd?
+    mmd
+  end
+
   private
 
   def root
@@ -84,7 +96,8 @@ class Vault
       add_title: config['add_title'] || false,
       convert_tags: config['convert_tags'] || false,
       obsidian_links: config['obsidian_links'] || false,
-      convert_markdown_links: config['convert_markdown_links'] || false
+      convert_markdown_links: config['convert_markdown_links'] || false,
+      marked_processor: config['marked_processor'].downcase || 'discount'
     }
   end
 end
@@ -220,6 +233,7 @@ $stdin.readlines.each do |line|
         replacements[wikilink] = "[#{label}](obsidian://vault/#{vault}/#{ERB::Util.url_encode("#{link}#{anchor}")})"
       end
 
+      # Replace solitary anchors with appropriately-formatted anchor links based on Marked processor
       line.scan(/\[(?<label>.*?)\]\(#(?<anchor>.*?)\)/) do
         m = Regexp.last_match
         wikilink = m[0]


### PR DESCRIPTION
This will need your review, but here's what I'm thinking:

- Convert wiki links to obsidian:// urls
- Handle `[]()` format links which Obsidian seems inclined to create nowadays

I'm using your existing root method to determine the vault name. I'm not a regular Obsidian user, so I don't know what pitfalls this might run into.