### PR TITLE
When converting #tags, add a search link back to obsidian

### DIFF
--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -232,6 +232,8 @@ $stdin.readlines.each do |line|
       # Match []() style links and convert to Obsidian urls
       line.scan(/\[(?<label>.*?)\]\((?<note>[^#]+)(?:\.md)?(?<anchor>#.*?)?\)/) do
         m = Regexp.last_match
+        next if m['note'] =~ /^http/
+
         wikilink = m[0]
         label = m['label']
         link = m['note']

--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -216,9 +216,9 @@ $stdin.readlines.each do |line|
     # Style #tags (settings['convert_tags'])
     if Vault.instance.convert_tags?
       if Vault.instance.obsidian_links?
-        line.gsub!(/(?<=\A|\s)#(\S+)/, "<span class=\"mkstyledtag\"><a href=\"obsidian://search?vault=#{vault}&query=tag%3A\\1\">#\\1</a></span>")
+        line.gsub!(/(?<=\A|\s)#([^# ]+)/, "<span class=\"mkstyledtag\"><a href=\"obsidian://search?vault=#{vault}&query=tag%3A\\1\">#\\1</a></span>")
       else
-        line.gsub!(/(?<=\A|\s)#(\S+)/, '<span class="mkstyledtag">#\1</span>')
+        line.gsub!(/(?<=\A|\s)#([^# ]+)/, '<span class="mkstyledtag">#\1</span>')
       end
     end
     # Fix all [[WikiLinks]]

--- a/obsidian-md-filter
+++ b/obsidian-md-filter
@@ -214,7 +214,13 @@ $stdin.readlines.each do |line|
     # Remove emojis if needed
     line.gsub!(EMOJI_REGEX, '') if Vault.instance.strip_emojis?
     # Style #tags (settings['convert_tags'])
-    line.gsub!(/(?<=\A|\s)#(\S+)/, '<span class="mkstyledtag">#\1</span>') if Vault.instance.convert_tags?
+    if Vault.instance.convert_tags?
+      if Vault.instance.obsidian_links?
+        line.gsub!(/(?<=\A|\s)#(\S+)/, "<span class=\"mkstyledtag\"><a href=\"obsidian://search?vault=#{vault}&query=tag%3A\\1\">#\\1</a></span>")
+      else
+        line.gsub!(/(?<=\A|\s)#(\S+)/, '<span class="mkstyledtag">#\1</span>')
+      end
+    end
     # Fix all [[WikiLinks]]
     replacements = if Vault.instance.obsidian_links?
                      obsidian_links(line, vault)


### PR DESCRIPTION
One more quick addition and then I'll quit:

- When convert_tags is true, if obsidian_links is also true, link the tag to an obsidian search url for tag:TAG.